### PR TITLE
Add cd with Github Actions for Android

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,22 +1,12 @@
-name: CI/CD
+name: CD
 
 on:
   push:
-    branches:
-      - master
-  pull_request:
+     tags:
+       - '*'
 
 jobs:
-  set-up:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
-  test:
-    needs: set-up
+  cd:
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -37,20 +27,6 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-
-      - name: Flutter Pub get
-        run: flutter pub get
-
-      - name: Flutter Analyze
-        run: flutter analyze
-
-      - name: Unit Test
-        timeout-minutes: 5
-        run: flutter test test/unit_test.dart
-
-      - name: Widget Test
-        timeout-minutes: 5
-        run: flutter test test/widget_test.dart
 
       - name: Build Android
         timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  set-up:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+  ci:
+    needs: set-up
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+    runs-on: macos-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+
+      - name: Setup Flutter SDK
+        timeout-minutes: 10
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Flutter Pub get
+        run: flutter pub get
+
+      - name: Flutter Analyze
+        run: flutter analyze
+
+      - name: Unit Test
+        timeout-minutes: 5
+        run: flutter test test/unit_test.dart
+
+      - name: Widget Test
+        timeout-minutes: 5
+        run: flutter test test/widget_test.dart
+
+      - name: Build iOS
+        timeout-minutes: 10
+        run: flutter build ios --no-codesign
+
+      - name: Build Android
+        timeout-minutes: 10
+        run: flutter build appbundle

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -52,29 +52,29 @@ jobs:
         timeout-minutes: 5
         run: flutter test test/widget_test.dart
 
-      - name: Build iOS
-        timeout-minutes: 10
-        run: flutter build ios --no-codesign
-
+  upload:
+    needs: test
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+    runs-on: macos-latest
+    steps:
       - name: Build Android
         timeout-minutes: 10
         run: flutter build appbundle
-
-      - name: Archive Android Build
-        run: zip -r build/app/outputs/bundle/release/app-release.aab.zip build/app/outputs/bundle/release/app-release.aab
      
       - name: Upload Android Build Artifact
         uses: actions/upload-artifact@v4
         with:
           name: android-app
-          path: build/app/outputs/bundle/release/app-release.aab.zip
-     
-      - name: Archive iOS Build
-        run: tar -czvf build/ios/iphoneos/app.ipa.tar.gz build/ios/iphoneos/app.ipa
-     
-      - name: Upload iOS Build Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-app
-          path: build/ios/iphoneos/app.ipa.tar.gz
+          path: build/app/outputs/bundle/release/app-release.aab
+      
+      #TODO: Add iOS build
     
+      - name: Create and Upload Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            build/app/outputs/bundle/release/app-release.aab
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI/CD
 
 on:
   push:
@@ -59,3 +59,22 @@ jobs:
       - name: Build Android
         timeout-minutes: 10
         run: flutter build appbundle
+
+      - name: Archive Android Build
+        run: zip -r build/app/outputs/bundle/release/app-release.aab.zip build/app/outputs/bundle/release/app-release.aab
+     
+      - name: Upload Android Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-app
+          path: build/app/outputs/bundle/release/app-release.aab.zip
+     
+      - name: Archive iOS Build
+        run: tar -czvf build/ios/iphoneos/app.ipa.tar.gz build/ios/iphoneos/app.ipa
+     
+      - name: Upload iOS Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-app
+          path: build/ios/iphoneos/app.ipa.tar.gz
+    

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -52,13 +52,6 @@ jobs:
         timeout-minutes: 5
         run: flutter test test/widget_test.dart
 
-  upload:
-    needs: test
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-    runs-on: macos-latest
-    steps:
       - name: Build Android
         timeout-minutes: 10
         run: flutter build appbundle


### PR DESCRIPTION
Since iOS requires a signature, it will not be implemented this time and will be postponed until later.

- [x] Investigate the Actions tool
*actions/create-release is deprecated and softprops/actions-gh-release is recommended instead.

- [x] Create a workflow for CD
Create a workflow that runs triggered by creating tags and allows the results to be downloaded in a release tab.